### PR TITLE
persist comments

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,9 @@
             android:name="com.google.android.geo.API_KEY"
             android:value="AIzaSyD4JaHC87dqrJ-qLSVveoHnaCv1JJSnPp8"/>
 
-        <activity android:name=".activities.Comments"></activity>
+        <activity android:name=".activities.Comments"
+            android:windowSoftInputMode="adjustPan"
+            />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/codepath/cribslist/activities/Comments.java
+++ b/app/src/main/java/com/codepath/cribslist/activities/Comments.java
@@ -11,6 +11,7 @@ import android.widget.EditText;
 
 import com.codepath.cribslist.R;
 import com.codepath.cribslist.adapters.CommentsAdapter;
+import com.codepath.cribslist.helper.SharedPref;
 import com.codepath.cribslist.models.Comment;
 import com.codepath.cribslist.network.CribslistClient;
 
@@ -22,6 +23,7 @@ public class Comments extends AppCompatActivity implements CribslistClient.GetCo
     LinearLayoutManager layoutManager;
     ArrayList<Comment> comments;
     EditText commentBox;
+    String threadId;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -42,7 +44,7 @@ public class Comments extends AppCompatActivity implements CribslistClient.GetCo
         mAdapter = new CommentsAdapter(comments);
         mRecyclerView.setLayoutManager(layoutManager);
         mRecyclerView.setAdapter(mAdapter);
-        String threadId = getIntent().getStringExtra("thread_id");
+        threadId = getIntent().getStringExtra("thread_id");
         CribslistClient.getCommentsForId(threadId, this);
     }
 
@@ -60,9 +62,14 @@ public class Comments extends AppCompatActivity implements CribslistClient.GetCo
 
     public void submitComment(View view) {
         String c = commentBox.getText().toString();
-        Comment newComment = new Comment("morgan", c);
+        SharedPref sp = SharedPref.getInstance();
+        Comment newComment = new Comment(sp.getEmail(), c);
+        long uid = Long.parseLong(sp.getUserId());
+        newComment.setUser_id(uid);
         commentBox.setText("");
         comments.add(newComment);
+
         mAdapter.notifyItemInserted(comments.size() - 1);
+        CribslistClient.addComment(newComment, threadId);
     }
 }

--- a/app/src/main/java/com/codepath/cribslist/activities/ItemDetail.java
+++ b/app/src/main/java/com/codepath/cribslist/activities/ItemDetail.java
@@ -49,6 +49,7 @@ public class ItemDetail extends AppCompatActivity {
     private Button inquire;
     private ImageView blurry;
     private View base;
+    private Item item;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -109,7 +110,7 @@ public class ItemDetail extends AppCompatActivity {
         bounds.setDuration(200);
         bounds.setInterpolator(new AccelerateDecelerateInterpolator());
         getWindow().setSharedElementEnterTransition(bounds);
-        Item item = i.getParcelableExtra("item");
+        item = i.getParcelableExtra("item");
         long uid = item.getUid();
         loadItemDetail(uid);
         mSlider = findViewById(R.id.slider);
@@ -205,12 +206,17 @@ public class ItemDetail extends AppCompatActivity {
     }
 
 
-    public void showComments(MenuItem item) {
+    public void showComments(MenuItem menuItem) {
         Intent intent = new Intent(ItemDetail.this, Comments.class);
-        intent.putExtra("thread_id", "1234");
+        intent.putExtra("thread_id", String.valueOf(item.getUid()));
         startActivity(intent);
     }
 
     public void writeEmail(MenuItem item) {
+    }
+
+    public void flagItem(MenuItem item) {
+        mDrawer.closeDrawers();
+        Toast.makeText(ItemDetail.this, "Content Flagged and sent for review", Toast.LENGTH_LONG).show();
     }
 }

--- a/app/src/main/java/com/codepath/cribslist/adapters/CommentsAdapter.java
+++ b/app/src/main/java/com/codepath/cribslist/adapters/CommentsAdapter.java
@@ -35,8 +35,7 @@ public class CommentsAdapter extends RecyclerView.Adapter<CommentsAdapter.Commen
 
     }
 
-    public CommentsAdapter(ArrayList<Comment> myDataset) { mDataset = myDataset;
-    }
+    public CommentsAdapter(ArrayList<Comment> myDataset) { mDataset = myDataset; }
 
     @Override
     public CommentsViewHolder onCreateViewHolder( ViewGroup parent,

--- a/app/src/main/java/com/codepath/cribslist/models/Comment.java
+++ b/app/src/main/java/com/codepath/cribslist/models/Comment.java
@@ -15,6 +15,22 @@ public class Comment {
         return comment_id;
     }
 
+    public void setComment_id(String comment_id) {
+        this.comment_id = comment_id;
+    }
+
+    public void setUser_id(Long user_id) {
+        this.user_id = user_id;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public void setThread_id(long thread_id) {
+        this.thread_id = thread_id;
+    }
+
     public Long getUser_id() {
         return user_id;
     }

--- a/app/src/main/java/com/codepath/cribslist/network/CribslistClient.java
+++ b/app/src/main/java/com/codepath/cribslist/network/CribslistClient.java
@@ -37,7 +37,7 @@ public class CribslistClient {
         void handleGetComments(ArrayList<Comment> comments);
     }
 
-    public static final String BASE_URL = "https://cribslist.herokuapp.com/";
+    public static final String BASE_URL = "http://cribslist.herokuapp.com/";
 
     public static void getAccountDetail(final GetAccountDelegate delegate) {
         String apiUrl = BASE_URL + "account/" + SharedPref.getInstance().getUserId();
@@ -209,7 +209,7 @@ public class CribslistClient {
     public static void getCommentsForId(String threadId, final GetComments getComments){
         ArrayList<Comment> comments = new ArrayList<>();
         AsyncHttpClient client = new AsyncHttpClient();
-        String url = BASE_URL + "/comments/" + threadId;
+        String url = BASE_URL + "comments/" + threadId;
         client.get(url, new JsonHttpResponseHandler() {
             @Override
             public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
@@ -225,6 +225,48 @@ public class CribslistClient {
             public void onSuccess(int statusCode, Header[] headers, JSONArray response) {
                 super.onSuccess(statusCode, headers, response);
                 getComments.handleGetComments(Comment.fromJSONArray(response));
+            }
+
+            @Override
+            public void onFailure(int statusCode, Header[] headers, String responseString, Throwable throwable) {
+                throw new AssertionError(responseString);
+            }
+
+            @Override
+            public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
+                super.onFailure(statusCode, headers, throwable, errorResponse);
+            }
+
+            @Override
+            public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONArray errorResponse) {
+                super.onFailure(statusCode, headers, throwable, errorResponse);
+            }
+        });
+    }
+
+    public static void addComment(Comment c, String threadId){
+        AsyncHttpClient client = new AsyncHttpClient();
+        String url = BASE_URL + "comments/" + threadId;
+        RequestParams params = new RequestParams();
+        params.put("user_id", c.getUser_id());
+        params.put("username", c.getUsername());
+        params.put("text", c.getText());
+        params.put("thread_id", threadId);
+        params.setForceMultipartEntityContentType(true);
+        client.post(url, params, new JsonHttpResponseHandler() {
+            @Override
+            public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
+                super.onSuccess(statusCode, headers, response);
+            }
+
+            @Override
+            public void onSuccess(int statusCode, Header[] headers, String responseString) {
+                super.onSuccess(statusCode, headers, responseString);
+            }
+
+            @Override
+            public void onSuccess(int statusCode, Header[] headers, JSONArray response) {
+                super.onSuccess(statusCode, headers, response);
             }
 
             @Override

--- a/app/src/main/res/layout/activity_comments.xml
+++ b/app/src/main/res/layout/activity_comments.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".activities.Comments"
     android:background="@drawable/bg"
+    android:isScrollContainer="false"
     >
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/item_view.xml
+++ b/app/src/main/res/layout/item_view.xml
@@ -8,9 +8,6 @@
     android:layout_marginBottom="24dp"
     android:background="@drawable/tile_background"
     android:elevation="2dp"
-    android:clickable="true"
-    android:focusable="true"
-    android:foreground="?android:attr/selectableItemBackground"
     android:transitionName="main"
     >
     <ImageView

--- a/app/src/main/res/menu/detail_menu.xml
+++ b/app/src/main/res/menu/detail_menu.xml
@@ -11,5 +11,10 @@
                 android:title="@string/comment"
                 android:onClick="showComments"
                 />
+            <item
+                android:id="@+id/nav_third_fragment"
+                android:title="@string/flag"
+                android:onClick="flagItem"
+                />
         </group>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,5 @@
     <string name="enter_location">Enter Location</string>
     <string name="email">Email</string>
     <string name="comment">Comment</string>
+    <string name="flag">Flag</string>
 </resources>


### PR DESCRIPTION
Comments are now persisted in the DB. I used the `Item` id as the `thread_id` for the comments.

![comments](https://user-images.githubusercontent.com/6319250/47949202-0ada3e80-defc-11e8-8ef5-2dd7bbb0bff8.gif)

In adding this i realized some of the items have the same id bc I used Date.now() and looped over the json array to create the original items in the db. Anyways I can clean up that data. I also made updates and now persist images on cloudinary. I think we have up to 10gb on there free
